### PR TITLE
update to v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2026-05-13] - Release v1.5.2
+
+### Fixed
+- **Critical Crash**: Application no longer crashes when changing waveform from Sine to Square/Triangle/Sawtooth
+  - Root cause: Null pointer access to `m_visStimDialog` in waveform change handlers
+  - Added proper null checks before calling `syncWaveType()`
+  - Affected: `onWaveformChanged()` and `onToneTypeComboIndexChanged()`
+
+### Improved
+- Visual stimulation dialog now safely handles uninitialized states
+- Stability improvements during tone type switching (BINAURAL/ISOCHRONIC/GENERATOR)
+
+---
+
 ## [2026-04-20] - Release v1.5.1
 ### Added
 - **Dark Theme Mode**: Full dark theme support with View → Dark Theme toggle for reduced eye strain in low-light environments

--- a/io.github.alamahant.BinauralPlayer.yml
+++ b/io.github.alamahant.BinauralPlayer.yml
@@ -22,5 +22,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/alamahant/BinauralPlayer.git
-        tag: v1.5.1
-        commit: 9efbba71f7b01c65f74b89ea90b449a4e1dcb881
+        tag: v1.5.2
+        commit: cc2c978990ddf94bcd5c3b3acfc1d321363de1e8


### PR DESCRIPTION
## [2026-05-13] - Release v1.5.2

### Fixed
- **Critical Crash**: Application no longer crashes when changing waveform from Sine to Square/Triangle/Sawtooth
  - Root cause: Null pointer access to `m_visStimDialog` in waveform change handlers
  - Added proper null checks before calling `syncWaveType()`
  - Affected: `onWaveformChanged()` and `onToneTypeComboIndexChanged()`

### Improved
- Visual stimulation dialog now safely handles uninitialized states
- Stability improvements during tone type switching (BINAURAL/ISOCHRONIC/GENERATOR)

---