### PR TITLE
update to v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## [2026-06-01] - Release v1.6.0
+
+### Added
+- **Decoupled Video & Flicker Widgets from Tab System**
+  - Video player now opens in independent floating window (no tab embedding)
+  - Visual Stimulation (Flicker) now opens in independent floating window
+  - Video and Flicker can be used simultaneously without mode switching
+  - Removed all `m_isVideoEnabled` conditional logic
+
+- **Playlist Track Persistence**
+  - Each playlist now remembers its last selected track when switching tabs
+  - Restores selection after tab switching, track removal, and playlist operations
+  - Uses `QMap<QString, int>` to store last track index per playlist
+
+- **Unified File Extension System**
+  - Single master list `ConstantGlobals::allMediaExtensions` for all media formats
+  - Duplicate file detection using `QSet` prevents adding same file twice
+  - User feedback dialogs for unsupported formats and duplicates
+  - Applies to: Load Music, Drag & Drop, File Association, and Streams
+
+- **Improved Playlist Management**
+  - Load playlist directly into current tab with confirmation before overwriting
+  - Save All Playlists now provides detailed success/error summary with playlist names
+  - Auto-selects first track after loading a playlist
+
+- **Flicker Window Improvements**
+  - Fullscreen mode removes titlebar for immersive experience
+  - VisStimDialog correctly reappears when window is reopened
+  - Window opens larger (1024x600) and remembers size after fullscreen exit
+
+### Fixed
+- Fixed duplicate file detection inconsistencies between file dialog and drag & drop
+- Fixed event filter crash when accessing null `m_videoPlayerContainer`
+- Fixed playlist tab close confirmation removing map entries before user confirmation
+- Fixed missing map entry rename when renaming playlists
+- Fixed `onRemoveTrackClicked` using wrong track index variable
+
+### Changed
+- Simplified `loadPlaylistFromFile` to load into current tab (no automatic new tab creation)
+- Removed redundant extension validation in `processDroppedFiles` (dragEnterEvent handles it)
+- Cleaned up `onSaveAllPlaylistsClicked` with better user messaging
+- Removed overcomplicated `QLocalServer` single-instance code (back to simple multi-instance)
+
+### Removed
+- `m_isVideoEnabled` and all related conditional logic
+- Video Player and Video Playlist tabs from tab widget
+- `m_flickerOriginalTabIndex` and tab visibility code
+- Hardcoded extension lists replaced with `allMediaExtensions`
+
+---
+
 ## [2026-05-17] - Release v1.5.3
 
 ### Added

--- a/io.github.alamahant.BinauralPlayer.yml
+++ b/io.github.alamahant.BinauralPlayer.yml
@@ -22,7 +22,14 @@ modules:
     sources:
       - type: file
         url: https://github.com/yt-dlp/yt-dlp/releases/download/2026.03.17/yt-dlp_linux
+        only-arches: [x86_64]
         sha256: c2b0189f581fe4a2ddd41954f1bcb7d327db04b07ed0dea97e4f1b3e09b5dd8e
+        dest-filename: yt-dlp
+
+      - type: file
+        url: https://github.com/yt-dlp/yt-dlp/releases/download/2026.03.17/yt-dlp_linux_aarch64
+        only-arches: [aarch64]
+        sha256: 6bfa19736181da9e2e066f9c767da2f24fdcc5e148fa5034d1feb09132f89ad5
         dest-filename: yt-dlp
 
   - name: Binauralplayer

--- a/io.github.alamahant.BinauralPlayer.yml
+++ b/io.github.alamahant.BinauralPlayer.yml
@@ -22,7 +22,14 @@ modules:
     sources:
       - type: file
         url: https://github.com/yt-dlp/yt-dlp/releases/download/2026.03.17/yt-dlp_linux
+        only-arches: [x86_64]
         sha256: c2b0189f581fe4a2ddd41954f1bcb7d327db04b07ed0dea97e4f1b3e09b5dd8e
+        dest-filename: yt-dlp
+
+      - type: file
+        url: https://github.com/yt-dlp/yt-dlp/releases/download/2026.03.17/yt-dlp_linux_aarch64
+        only-arches: [aarch64]
+        sha256: 6bfa19736181da9e2e066f9c767da2f24fdcc5e148fa5034d1feb09132f89ad5
         dest-filename: yt-dlp
 
   - name: Binauralplayer
@@ -33,5 +40,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/alamahant/BinauralPlayer.git
-        tag: v1.5.3
-        commit: e20658369f425388b530c1c088da051f2487ac55
+        tag: v1.6.0
+        commit: 6812d0af64f5bb28fe569fedaed0ca36a72fda6a

--- a/io.github.alamahant.BinauralPlayer.yml
+++ b/io.github.alamahant.BinauralPlayer.yml
@@ -22,14 +22,7 @@ modules:
     sources:
       - type: file
         url: https://github.com/yt-dlp/yt-dlp/releases/download/2026.03.17/yt-dlp_linux
-        only-arches: [x86_64]
         sha256: c2b0189f581fe4a2ddd41954f1bcb7d327db04b07ed0dea97e4f1b3e09b5dd8e
-        dest-filename: yt-dlp
-
-      - type: file
-        url: https://github.com/yt-dlp/yt-dlp/releases/download/2026.03.17/yt-dlp_linux_aarch64
-        only-arches: [aarch64]
-        sha256: 6bfa19736181da9e2e066f9c767da2f24fdcc5e148fa5034d1feb09132f89ad5
         dest-filename: yt-dlp
 
   - name: Binauralplayer


### PR DESCRIPTION
## [2026-06-01] - Release v1.6.0

### Added
- **Decoupled Video & Flicker Widgets from Tab System**
  - Video player now opens in independent floating window (no tab embedding)
  - Visual Stimulation (Flicker) now opens in independent floating window
  - Video and Flicker can be used simultaneously without mode switching
  - Removed all `m_isVideoEnabled` conditional logic

- **Playlist Track Persistence**
  - Each playlist now remembers its last selected track when switching tabs
  - Restores selection after tab switching, track removal, and playlist operations
  - Uses `QMap<QString, int>` to store last track index per playlist

- **Unified File Extension System**
  - Single master list `ConstantGlobals::allMediaExtensions` for all media formats
  - Duplicate file detection using `QSet` prevents adding same file twice
  - User feedback dialogs for unsupported formats and duplicates
  - Applies to: Load Music, Drag & Drop, File Association, and Streams

- **Improved Playlist Management**
  - Load playlist directly into current tab with confirmation before overwriting
  - Save All Playlists now provides detailed success/error summary with playlist names
  - Auto-selects first track after loading a playlist

- **Flicker Window Improvements**
  - Fullscreen mode removes titlebar for immersive experience
  - VisStimDialog correctly reappears when window is reopened
  - Window opens larger (1024x600) and remembers size after fullscreen exit

### Fixed
- Fixed duplicate file detection inconsistencies between file dialog and drag & drop
- Fixed event filter crash when accessing null `m_videoPlayerContainer`
- Fixed playlist tab close confirmation removing map entries before user confirmation
- Fixed missing map entry rename when renaming playlists
- Fixed `onRemoveTrackClicked` using wrong track index variable

### Changed
- Simplified `loadPlaylistFromFile` to load into current tab (no automatic new tab creation)
- Removed redundant extension validation in `processDroppedFiles` (dragEnterEvent handles it)
- Cleaned up `onSaveAllPlaylistsClicked` with better user messaging
- Removed overcomplicated `QLocalServer` single-instance code (back to simple multi-instance)

### Removed
- `m_isVideoEnabled` and all related conditional logic
- Video Player and Video Playlist tabs from tab widget
- `m_flickerOriginalTabIndex` and tab visibility code
- Hardcoded extension lists replaced with `allMediaExtensions`

---