### PR TITLE
update to v1.6.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [2026-06-26] - Release v1.6.31
+NOTE: This is a bump if v1.6.3 because it failed to be published even after successfull PR merging
+### Added
+- **Background Noise Layer**
+  - White, Pink, Brown, and Grey noise generation
+  - Adjustable mix level (0.00 to 1.00)
+  - Toggle on/off via toolbar button
+  - Real-time mixing with binaural/isochronic tones
+  - Tooltips for all noise controls
+  - Reset support for noise settings
+
+---
+
 ## [2026-06-26] - Release v1.6.3
 
 ### Added

--- a/io.github.alamahant.BinauralPlayer.yml
+++ b/io.github.alamahant.BinauralPlayer.yml
@@ -40,5 +40,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/alamahant/BinauralPlayer.git
-        tag: v1.6.3
-        commit: 1faeb555b70134595454f7b8ec3b5493bd7c9c2c
+        tag: v1.6.31
+        commit: 32e28ecd7f555688a56be1d121d7349ac8200d0e

--- a/io.github.alamahant.BinauralPlayer.yml
+++ b/io.github.alamahant.BinauralPlayer.yml
@@ -41,4 +41,4 @@ modules:
       - type: git
         url: https://github.com/alamahant/BinauralPlayer.git
         tag: v1.6.31
-        commit: 32e28ecd7f555688a56be1d121d7349ac8200d0e
+        commit: e135f5120803a6a02b5a88630a94aa9e510ab623


### PR DESCRIPTION
## [2026-06-26] - Release v1.6.31
NOTE: This is a bump if v1.6.3 because it failed to be published even after successfull PR merging
### Added
- **Background Noise Layer**
  - White, Pink, Brown, and Grey noise generation
  - Adjustable mix level (0.00 to 1.00)
  - Toggle on/off via toolbar button
  - Real-time mixing with binaural/isochronic tones
  - Tooltips for all noise controls
  - Reset support for noise settings

---